### PR TITLE
fix: Python 3 except syntax + CI/pre-commit hardening

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.14"]
+        python-version: ["3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,12 @@ repos:
         additional_dependencies:
           - types-requests # Changed from types-requests
 
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.19.1
+    hooks:
+      - id: pyupgrade
+        args: [--py313-plus]
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0 # Use the ref you want to point at
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ norecursedirs = ["examples", "docs", ".tox", "test_env"]
 ignore_missing_imports = true
 
 [tool.ruff]
-target-version = "py314"
+target-version = "py313"
 line-length = 120
 extend-exclude = ["examples"]
 

--- a/src/pybticino/const.py
+++ b/src/pybticino/const.py
@@ -22,7 +22,7 @@ def get_client_id() -> str:
     try:
         # Ensure correct padding if needed, though standard encoding usually handles it
         return base64.b64decode(_ENCODED_CLIENT_ID).decode("utf-8")
-    except binascii.Error, UnicodeDecodeError:
+    except (binascii.Error, UnicodeDecodeError):
         # Log error or raise a specific exception if decoding fails
         _LOGGER.exception("Error decoding client ID")
         return ""
@@ -32,7 +32,7 @@ def get_client_secret() -> str:
     """Return the Base64 decoded client secret."""
     try:
         return base64.b64decode(_ENCODED_CLIENT_SECRET).decode("utf-8")
-    except binascii.Error, UnicodeDecodeError:
+    except (binascii.Error, UnicodeDecodeError):
         _LOGGER.exception("Error decoding client secret")
         return ""
 


### PR DESCRIPTION
## Summary

- **Fix `SyntaxError` on Python 3.13**: `except binascii.Error, UnicodeDecodeError:` (Python 2 syntax) → `except (binascii.Error, UnicodeDecodeError):` in `const.py` lines 25 and 35, introduced in commit 77f3d2b
- **Fix ruff `target-version`**: changed from `py314` to `py313` to match `requires-python = ">=3.13"`. With `py314`, ruff format was stripping the parentheses from `except (A, B):` because Python 3.14 (PEP 760) allows bare `except A, B:` — but that's a SyntaxError on 3.13
- **Add Python 3.13 to CI test matrix**: tests now run on both 3.13 and 3.14
- **Add `pyupgrade` pre-commit hook** (`--py313-plus`): automatically detects and rewrites Python 2 syntax patterns, preventing regressions like this

Closes #15

## Test plan
- [ ] Verify `python3.13 -c "import pybticino"` no longer raises `SyntaxError`
- [ ] Verify CI passes on both Python 3.13 and 3.14
- [ ] Verify `pre-commit run pyupgrade --all-files` passes clean
- [ ] Verify `ruff format --check` passes (no longer strips parentheses from except clauses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)